### PR TITLE
Allow sequeler to access localhost through network

### DIFF
--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -33,6 +33,8 @@
     /* dconf */
     "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
     "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    /* access localhost databases */
+    "--share=network"
   ],
   "modules": [{
       "name": "libgee",


### PR DESCRIPTION
I think this is needed to access local databases. For me it is at least. I think this is a useful default, since most developers will try to access local databases.