### PR TITLE
Update GNOME runtime to 48

### DIFF
--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -52,7 +52,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download-fallback.gnome.org/sources/libgda/5.2/libgda-5.2.9.tar.xz",
+          "url": "https://download.gnome.org/sources/libgda/5.2/libgda-5.2.9.tar.xz",
           "sha256": "59caed8ca72b1ac6437c9844f0677f8a296d52cfd1c0049116026abfb1d87d9b"
         }
       ],

--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -1,10 +1,10 @@
 {
   "id": "com.github.alecaddd.sequeler",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "base": "io.elementary.BaseApp",
-  "base-version": "juno-23.08",
+  "base-version": "circe-24.08",
   "command": "com.github.alecaddd.sequeler",
   "finish-args": [
     "--share=ipc",
@@ -30,7 +30,8 @@
       "build-options": {
         "config-opts": [
           "--enable-gtk-doc=no"
-        ]
+        ],
+        "cflags": "-Wno-error=incompatible-pointer-types"
       },
       "sources": [
         {
@@ -47,7 +48,8 @@
           "--with-java=no",
           "--with-jni=no",
           "--with-oracle=no"
-        ]
+        ],
+        "cflags": "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration"
       },
       "sources": [
         {
@@ -65,7 +67,8 @@
               "--with-perl=no",
               "--with-libxml",
               "--with-openssl"
-            ]
+            ],
+            "cflags": "-Wno-error=incompatible-pointer-types"
           },
           "sources": [
             {


### PR DESCRIPTION
## Changes Summary
- Fix unresolved libgda URL
- Update GNOME runtime to 48
- Update elementary BaseApp to circe-24.08
- Do not treat some warnings that now treated as errors since GCC 14

## Checklist
- [x] Build succeeds with `flatpak-builder builddir com.github.alecaddd.sequeler.json --user --install --force-clean --install-deps-from=flathub`
- [x] The app launches successfully
